### PR TITLE
Show job.args as JSON object to allow multidimensional arrays

### DIFF
--- a/Resources/views/Default/queue_list.html.twig
+++ b/Resources/views/Default/queue_list.html.twig
@@ -55,14 +55,7 @@
                         <tr>
                             <td>{{ job.name }}</td>
                             <td>
-                                <ul class="unstyled">
-                                    {% for argname, argvalue in job.args %}
-                                        <li>
-                                            <strong>{{ argname }}</strong>
-                                            <span class="pull-right">{{ argvalue }}</span>
-                                        </li>
-                                    {% endfor %}
-                                </ul>
+                                {{ job.args | json_encode }}
                             </td>
                         </tr>
                     {% else %}


### PR DESCRIPTION
Otherwise you'll get an error:

`Notice: Array to string conversion in /Volumes/www/app/api/cache/dev/twig/54/c4/d0077558c826e523de25c5a3b822.php line 127") in BCCResqueBundle:Default:queue_list.html.twig at line 62.`
