### PR TITLE
Fixed bug + configurable vendor_dir

### DIFF
--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -23,15 +23,19 @@ class StartWorkerCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $globals = 'APP_INCLUDE='.$this->getContainer()->getParameter('kernel.root_dir').'/../vendor/autoload.php VVERBOSE=1 QUEUE='.$input->getArgument('queues');
+        $env = array(
+            'APP_INCLUDE' => $this->getContainer()->getParameter('bcc_resque.resque.vendor_dir').'/autoload.php',
+            'VVERBOSE'    => 1,
+            'QUEUE'       => $input->getArgument('queues')
+        );
 
-        $workerCommand = 'php '.$this->getContainer()->getParameter('kernel.root_dir').'/../vendor/chrisboulton/php-resque/resque.php';
+        $workerCommand = 'php '.$this->getContainer()->getParameter('bcc_resque.resque.vendor_dir').'/chrisboulton/php-resque/resque.php';
 
         if (!$input->getOption('foreground')) {
             $workerCommand = 'nohup '.$workerCommand.' > '.$this->getContainer()->getParameter('kernel.logs_dir').'/resque.log 2>&1 & echo $!';
         }
 
-        $process = new Process($globals.' '.$workerCommand);
+        $process = new Process($workerCommand, null, $env);
 
         $output->writeln(\sprintf('Starting worker <info>%s</info>', $process->getCommandLine()));
 

--- a/DependencyInjection/BCCResqueExtension.php
+++ b/DependencyInjection/BCCResqueExtension.php
@@ -24,5 +24,9 @@ class BCCResqueExtension extends Extension
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        if (isset($config['vendor_dir'])) {
+            $container->setParameter('bcc_resque.resque.vendor_dir', $config['vendor_dir']);
+        }
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,9 +20,12 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('bcc_resque');
 
-        // Here you should define the parameters that are allowed to
-        // configure your bundle. See the documentation linked above for
-        // more information on that topic.
+        $rootNode
+            ->children()
+                ->scalarNode('vendor_dir')
+                ->end()
+            ->end()
+        ;
 
         return $treeBuilder;
     }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,6 +6,7 @@
 
     <parameters>
         <parameter key="bcc_resque.resque.class">BCC\ResqueBundle\Resque</parameter>
+        <parameter key="bcc_resque.resque.vendor_dir">%kernel.root_dir%/../vendor</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
My application has a different directory structure so the location of the vendor_dir is different. This patch allows you to configure the vendor_dir via your config:

``` yaml
bcc_resque:
    vendor_dir: %kernel.root_dir%/../../vendor
```

If you leave it empty the default value will be used.

This patch also fixes the following error:

``` console
Ruud@imacruud:/www/apoio$ php app/console bcc:resque:worker-start -f hooks
Starting worker APP_INCLUDE=/Volumes/www/app/api/../../vendor/autoload.php VVERBOSE=1 QUEUE=hooks php /Volumes/www/app/api/../../vendor/chrisboulton/php-resque/resque.php
sh: /www/APP_INCLUDE=/Volumes/www/app/api/../../vendor/autoload.php: No such file or directory
sh: line 0: exec: /www/APP_INCLUDE=/Volumes/www/app/api/../../vendor/autoload.php: cannot execute: No such file or directory
```

By setting the ENV variables on the third parameter of `Symfony\Component\Process\Process`.
