### PR TITLE
Removed VVERBOSE to prevent flooding the resque.log

### DIFF
--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -25,7 +25,6 @@ class StartWorkerCommand extends ContainerAwareCommand
     {
         $env = array(
             'APP_INCLUDE' => $this->getContainer()->getParameter('bcc_resque.resque.vendor_dir').'/autoload.php',
-            'VVERBOSE'    => 1,
             'QUEUE'       => $input->getArgument('queues')
         );
 


### PR DESCRIPTION
I've removed it because otherwise the resque.log file will be flooded with this:

```
*** Checking queue
*** Sleeping for 5
```

Please merge and tag :)
