### PR TITLE
Move pruneDeadWorkers after configuration

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -16,6 +16,7 @@
                 <argument>%bcc_resque.resque.redis.port%</argument>
                 <argument>%bcc_resque.resque.redis.database%</argument>
             </call>
+            <call method="pruneDeadWorkers" />
         </service>
     </services>
 </container>

--- a/Resque.php
+++ b/Resque.php
@@ -17,10 +17,6 @@ class Resque
     function __construct(array $kernelOptions)
     {
         $this->kernelOptions = $kernelOptions;
-
-        // HACK, prune dead workers, just in case
-        $worker = new \Resque_Worker('temp');
-        $worker->pruneDeadWorkers();
     }
 
     public function setRedisConfiguration($host, $port, $database)
@@ -93,5 +89,12 @@ class Resque
         }
 
         return new Worker($worker);
+    }
+
+    public function pruneDeadWorkers()
+    {
+        // HACK, prune dead workers, just in case
+        $worker = new \Resque_Worker('temp');
+        $worker->pruneDeadWorkers();
     }
 }


### PR DESCRIPTION
As discussed in https://github.com/michelsalib/BCCResqueBundle/pull/13,
Redis configuration was happening after pruning, making it impossible to
run commands on a machine that did not have redis installed locally.

A cursory local check shows that this still works. 
