### PR TITLE
Make css usable if symfony is in subdirectory

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -4,7 +4,7 @@
         <meta charset="UTF-8" />
         <title>{% block title %}BCC Resque{% endblock %}</title>
         {% block stylesheets %}
-            <link rel="stylesheet" href="/bundles/bccresque/css/bootstrap.min.css"/>
+            <link rel="stylesheet" href="{{ asset('bundles/bccresque/css/bootstrap.min.css') }}" type="text/css" media="screen" />
             <style type="text/css">
                 body {
                     padding-top: 60px;


### PR DESCRIPTION
CSS was not loaded when Symfony is installed in a subdirectory due to the use of a fixed path
