### PR TITLE
allow kernel.root_dir to be overridden

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,10 +4,14 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="bcc_resque.kernel.root_dir">%kernel.root_dir%</parameter>
+    </parameters>
+    
     <services>
         <service id="bcc_resque.resque" class="%bcc_resque.resque.class%">
             <argument type="collection">
-                <argument key="kernel.root_dir">%kernel.root_dir%</argument>
+                <argument key="kernel.root_dir">%bcc_resque.kernel.root_dir%</argument>
                 <argument key="kernel.debug">%kernel.debug%</argument>
                 <argument key="kernel.environment">%kernel.environment%</argument>
             </argument>


### PR DESCRIPTION
When you're running in an environment in which the source is symlinked on deployment (e.g. capistrano) you need to be able to override the kernel root as seen by the ContainerAwareJob because it changes with each deployment.
