### PR TITLE
Removed date filter from failed_list.html.twig

### DIFF
--- a/Resources/views/Default/failed_list.html.twig
+++ b/Resources/views/Default/failed_list.html.twig
@@ -18,7 +18,7 @@
                 {% for job in jobs %}
                 <tr>
                     <td class="span1">{{ job.queueName }}</td>
-                    <td class="span2">{{ job.failedAt|date('Y-m-d H:i:s') }}</td>
+                    <td class="span2">{{ job.failedAt }}</td>
                     <td class="span4">{{ job.name }}</td>
                     <td class="span5">
                         {{ job.exceptionClass }}<br>


### PR DESCRIPTION
Otherwise you get this error:

An exception has been thrown during the rendering of a template ("DateTime::__construct(): Failed to parse time string (di mrt 26 12:46:53 UTC 2013) at position 0 (d): The timezone could not be found in the database") in BCCResqueBundle:Default:failed_list.html.twig at line 21.

This is because PHP-Resque uses a localized timestamp: 

``` php
$data->failed_at = strftime('%a %b %d %H:%M:%S %Z %Y');
```
