### PR TITLE
APP_INCLUDE should point to bootstrap.php.cache

### DIFF
--- a/Command/StartScheduledWorkerCommand.php
+++ b/Command/StartScheduledWorkerCommand.php
@@ -32,7 +32,7 @@ class StartScheduledWorkerCommand extends ContainerAwareCommand
         }
 
         $env = array(
-            'APP_INCLUDE' => $this->getContainer()->getParameter('kernel.root_dir').'/autoload.php',
+            'APP_INCLUDE' => $this->getContainer()->getParameter('kernel.root_dir').'/bootstrap.php.cache',
             'VVERBOSE'    => 1,
             'RESQUE_PHP' => $this->getContainer()->getParameter('bcc_resque.resque.vendor_dir').'/chrisboulton/php-resque/lib/Resque.php',
         );

--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -27,7 +27,7 @@ class StartWorkerCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $env = array(
-            'APP_INCLUDE' => $this->getContainer()->getParameter('kernel.root_dir').'/autoload.php',
+            'APP_INCLUDE' => $this->getContainer()->getParameter('kernel.root_dir').'/bootstrap.php.cache',
             'QUEUE'       => $input->getArgument('queues'),
             'VERBOSE'     => 1,
             'COUNT'       => $input->getOption('count'),


### PR DESCRIPTION
I just found out that it is wrong to use `vendor/autoload.php` as the `APP_INCLUDE` environment parameter for PHP Resque.

We have to use `app/bootstrap.php.cache` because this one also initializes the `AnnotationRegistry` autoloader.

I got stuck with this error:

```
[Semantical Error] The annotation "@Doctrine\ORM\Mapping\Index" in class AppBundle\Entity\Message does not exist, or could not be auto-loaded.
```
