### PR TITLE
Setting right context for proces in windows

### DIFF
--- a/Command/StartScheduledWorkerCommand.php
+++ b/Command/StartScheduledWorkerCommand.php
@@ -61,6 +61,19 @@ class StartScheduledWorkerCommand extends ContainerAwareCommand
             $workerCommand = 'nohup ' . $workerCommand . ' > ' . $logFile .' 2>&1 & echo $!';
         }
 
+		// In windows: When you pass an environment to CMD it replaces the old environment
+		// That means we create a lot of problems with respect to user accounts and missing vars
+		// this is a workaround where we add the vars to the existing environment. 
+		if (defined('PHP_WINDOWS_VERSION_BUILD'))
+		{
+			foreach($env as $key => $value)
+			{
+				putenv($key."=". $value);
+			}
+			$env = null;
+		}
+
+
         $process = new Process($workerCommand, null, $env, null, null);
 
         $output->writeln(\sprintf('Starting worker <info>%s</info>', $process->getCommandLine()));

--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -69,6 +69,19 @@ class StartWorkerCommand extends ContainerAwareCommand
                 '%logs_dir%' => $this->getContainer()->getParameter('kernel.logs_dir'),
             ));
         }
+		
+		
+		// In windows: When you pass an environment to CMD it replaces the old environment
+		// That means we create a lot of problems with respect to user accounts and missing vars
+		// this is a workaround where we add the vars to the existing environment. 
+		if (defined('PHP_WINDOWS_VERSION_BUILD'))
+		{
+			foreach($env as $key => $value)
+			{
+				putenv($key."=". $value);
+			}
+			$env = null;
+		}
 
         $process = new Process($workerCommand, null, $env, null, null);
 


### PR DESCRIPTION
Fixes an issue where windows would lose the context of a new process and introducing problems with environment settings.

This fix sets the env-vars on the current context and provided the current context to new new process instead of creating a whole new context. 

Probably fixes #25 also
