### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -35,7 +35,7 @@ Add to your `bcc-resque-bundle` to your dependencies:
 {
     "require": {
         ...
-        "bcc/resque-bundle": "1.1"
+        "bcc/resque-bundle": "1.1.*"
     }
     ...
 }


### PR DESCRIPTION
Updated install section, using "1.1" failes with newest symfony version
