### PR TITLE
Only kill the workers running on the current machine

### DIFF
--- a/Command/StopWorkerCommand.php
+++ b/Command/StopWorkerCommand.php
@@ -26,7 +26,10 @@ class StopWorkerCommand extends ContainerAwareCommand
         $resque = $this->getContainer()->get('bcc_resque.resque');
 
         if ($input->getOption('all')) {
-            $workers = $resque->getWorkers();
+            $workers = $resque->getWorkers(true);
+            if (empty($workers)) {
+                $output->writeln('<comment>You don\'t have any workers on this machine.</comment>');
+            }
         } else {
             $worker = $resque->getWorker($input->getArgument('id'));
 

--- a/Resque.php
+++ b/Resque.php
@@ -127,11 +127,25 @@ class Resque
         return new Queue($queue);
     }
 
-    public function getWorkers()
+    public function getWorkers($local = false)
     {
+        $workers = \Resque_Worker::all();
+
+        if ($local) {
+            $hostname = php_uname('n');
+            
+            if(function_exists('gethostname')) {
+                $hostname = gethostname();
+            }
+
+            $workers = \array_filter($workers, function ($worker) use ($hostname) {
+                return strpos((string) $worker, $hostname . ':') === 0;
+            });
+        }
+
         return \array_map(function ($worker) {
             return new Worker($worker);
-        }, \Resque_Worker::all());
+        }, $workers);
     }
 
     public function getWorker($id)


### PR DESCRIPTION
Only kill the workers running on the current machine when parameter --all is used.
Fixes #63.
