### PR TITLE
Fix for array to string conversion Twig exception

### DIFF
--- a/Resources/views/Default/index.html.twig
+++ b/Resources/views/Default/index.html.twig
@@ -85,7 +85,7 @@
                                         {% for argname, argvalue in job.args %}
                                             <li>
                                                 <span>{{ argname }}</span>
-                                                <em class="pull-right">{{ dump(argvalue) }}</em>
+                                                <em class="pull-right">{{ argvalue | json_encode(constant('JSON_PRETTY_PRINT')) }}</em>
                                             </li>
                                         {% endfor %}
                                     </ul>


### PR DESCRIPTION
This fixes the problem discussed in #83 where a Twig runtime exception is thrown when one of the job arguments is an array (which is always the case with jobs which support a retry strategy). 

More here: https://github.com/michelsalib/BCCResqueBundle/issues/83
