### PR TITLE
PruneDeadWorkers > Resque_Worker always needs a logger, so give it a NullLogger

### DIFF
--- a/Resque.php
+++ b/Resque.php
@@ -2,6 +2,8 @@
 
 namespace BCC\ResqueBundle;
 
+use Psr\Log\NullLogger;
+
 class Resque
 {
     /**
@@ -175,6 +177,7 @@ class Resque
     {
         // HACK, prune dead workers, just in case
         $worker = new \Resque_Worker('temp');
+        $worker->setLogger(new NullLogger());
         $worker->pruneDeadWorkers();
     }
 


### PR DESCRIPTION
This morning Resque was failing and I had to restart some workers. After that, I couldn't get into the Dashboard because of this error:

```
PHP Fatal error:  Call to a member function log() on a non-object in /home/domains/domain.nl/app/releases/20140409085135/vendor/chrisboulton/php-resque/lib/Resque/Worker.php on line 440
```

This fixes it.
