### PR TITLE
Add job status checker.

### DIFF
--- a/Resque.php
+++ b/Resque.php
@@ -267,4 +267,16 @@ class Resque
             $job->args['bcc_resque.retry_strategy'] = $this->globalRetryStrategy;
         }
     }
+
+    /**
+     * Checks the status of a given job.
+     *
+     * @param string $job_id
+     *
+     * @return \Resque_Job_Status
+     */
+    public function getJobStatus($job_id)
+    {
+        return new \Resque_Job_Status($job_id);
+    }
 }


### PR DESCRIPTION
Direct calls to Resque_Job_Status will fail due to not having the loaded parameters.
