### PR TITLE
Respect SYMFONY_ENV and --env when starting workings

### DIFF
--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -59,6 +59,10 @@ class StartWorkerCommand extends ContainerAwareCommand
         if ($input->getOption('quiet')) {
             unset($env['VERBOSE']);
         }
+        
+        if ($input->getOption('env')) {
+	    $env['SYMFONY_ENV'] = $input->getOption('env');
+        }
 
         $redisHost     = $this->getContainer()->getParameter('bcc_resque.resque.redis.host');
         $redisPort     = $this->getContainer()->getParameter('bcc_resque.resque.redis.port');

--- a/ContainerAwareJob.php
+++ b/ContainerAwareJob.php
@@ -44,8 +44,15 @@ abstract class ContainerAwareJob extends Job
 
         require_once $file;
 
+         $env = 'dev';
+         if (isset($this->args['kernel.environment'])) {
+            $env = $this->args['kernel.environment'];
+         } elseif (getenv('SYMFONY_ENV')) {
+            $env = getenv('SYMFONY_ENV');
+         }
+
         return new $class(
-            isset($this->args['kernel.environment']) ? $this->args['kernel.environment'] : 'dev',
+            $env,
             isset($this->args['kernel.debug']) ? $this->args['kernel.debug'] : true
         );
     }


### PR DESCRIPTION
Similar to behavior of app/console, workers should respect --env and then SYMFONY_ENV.
