### PR TITLE
StartWorkerCommand: Return valid response

### DIFF
--- a/Command/StartWorkerCommand.php
+++ b/Command/StartWorkerCommand.php
@@ -108,5 +108,7 @@ class StartWorkerCommand extends ContainerAwareCommand
                 $output->writeln(\sprintf('<info>Worker started</info> %s:%s:%s', $hostname, $pid, $input->getArgument('queues')));
             }
         }
+        
+        return 0;
     }
 }


### PR DESCRIPTION
Return a valid response to the deployment tools like the one that we have on `BCCResqueBundle/Command/StopWorkerCommand.php`
